### PR TITLE
Make usage of the new stop semantics to properly shutdown the plugin

### DIFF
--- a/logstash-input-drupal_dblog.gemspec
+++ b/logstash-input-drupal_dblog.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'php_serialize'
+  s.add_runtime_dependency 'stud', '~> 0.0.22'
 
   if RUBY_PLATFORM == 'java'
     s.platform = RUBY_PLATFORM

--- a/spec/inputs/drupal_dblog_spec.rb
+++ b/spec/inputs/drupal_dblog_spec.rb
@@ -1,1 +1,8 @@
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/drupal_dblog"
+
+describe LogStash::Inputs::DrupalDblog do
+  it_behaves_like "an interruptible input plugin" do
+    let(:config) { { "databases" => {} } }
+  end
+end


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

Fixes #10 