### PR TITLE
Alias watchdog type column as "watchdog_type"

### DIFF
--- a/lib/logstash/inputs/drupal_dblog.rb
+++ b/lib/logstash/inputs/drupal_dblog.rb
@@ -226,7 +226,7 @@ class LogStash::Inputs::DrupalDblog < LogStash::Inputs::Base
   end # def check_database
 
   def get_db_rows(lastWid)
-    query = 'SELECT wid, uid, type AS watchdog_type, message, variables, severity, link, location, referer, hostname, timestamp from watchdog WHERE wid > ' + lastWid.to_s + " ORDER BY wid asc LIMIT " + @bulksize.to_s
+    query = 'SELECT wid, uid, type AS watchdog_type, message, CONVERT(variables USING utf8) AS variables, severity, link, location, referer, hostname, timestamp from watchdog WHERE wid > ' + lastWid.to_s + " ORDER BY wid asc LIMIT " + @bulksize.to_s
     return @client.query(query)
   end # def get_db_rows
 

--- a/lib/logstash/inputs/drupal_dblog.rb
+++ b/lib/logstash/inputs/drupal_dblog.rb
@@ -226,7 +226,7 @@ class LogStash::Inputs::DrupalDblog < LogStash::Inputs::Base
   end # def check_database
 
   def get_db_rows(lastWid)
-    query = 'SELECT * from watchdog WHERE wid > ' + lastWid.to_s + " ORDER BY wid asc LIMIT " + @bulksize.to_s
+    query = 'SELECT wid, uid, type AS watchdog_type, message, variables, severity, link, location, referer, hostname, timestamp from watchdog WHERE wid > ' + lastWid.to_s + " ORDER BY wid asc LIMIT " + @bulksize.to_s
     return @client.query(query)
   end # def get_db_rows
 

--- a/lib/logstash/inputs/drupal_dblog/jdbcconnection.rb
+++ b/lib/logstash/inputs/drupal_dblog/jdbcconnection.rb
@@ -12,7 +12,7 @@ class LogStash::DrupalDblogJavaMysqlConnection
   def initialize(host, username, password, database, port = nil)
     port ||= 3306
 
-    address = "jdbc:mysql://#{host}:#{port}/#{database}"
+    address = "jdbc:mysql://#{host}:#{port}/#{database}?useOldAliasMetadataBehavior=true"
     @connection = java.sql.DriverManager.getConnection(address, username, password)
   end # def initialize
 

--- a/logstash-input-drupal_dblog.gemspec
+++ b/logstash-input-drupal_dblog.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
 
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core", ">= 2.0.0", "< 6.0.0.alpha1"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'php_serialize'
   s.add_runtime_dependency 'stud', '~> 0.0.22'


### PR DESCRIPTION
Avoids clash with Elasticsearch type field.

---

I *have* signed the CLA. However I did add the email address of the commit author to this account *after* signing. Could someone at Elasticsearch let me know why the check still fails?

The build seems to have been failing for some time for different reasons.